### PR TITLE
`process-args` and `usage`

### DIFF
--- a/example/scripts/my-util
+++ b/example/scripts/my-util
@@ -26,7 +26,7 @@ positional-arg --var=cmdName subcommand
 # The subcommand arguments (including possibly sub-subcommand names).
 rest-arg --var=args args
 
-process-args "$@" || usage --short "$?"
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/buildy/clean
+++ b/scripts/lib/bashy-basics/buildy/clean
@@ -24,7 +24,7 @@ define-usage --with-help $'
 # Built output directory.
 opt-value --var=outDir out
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/buildy/ls-files
+++ b/scripts/lib/bashy-basics/buildy/ls-files
@@ -78,7 +78,7 @@ function parse-rest {
     fi
 }
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/buildy/make-distro
+++ b/scripts/lib/bashy-basics/buildy/make-distro
@@ -28,7 +28,7 @@ opt-value --var=outDir out
 # Directory containing the built project.
 positional-arg --var=builtDir built-dir
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/buildy/out-dir
+++ b/scripts/lib/bashy-basics/buildy/out-dir
@@ -43,7 +43,7 @@ opt-toggle --var=doCreate create
 opt-toggle --var=doPrint print
 opt-toggle --var=doRemove remove
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/buildy/pull-repo
+++ b/scripts/lib/bashy-basics/buildy/pull-repo
@@ -53,7 +53,7 @@ opt-value --var=tagSpec --filter='/./' tag
 # Repo URL.
 positional-arg --var=repoUrl repo-url
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/jarray
+++ b/scripts/lib/bashy-basics/jarray
@@ -33,7 +33,7 @@ opt-value --var=inputStyle --init=json --enum='json strings' input
 # The array elements.
 rest-arg --var=values values
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/jget
+++ b/scripts/lib/bashy-basics/jget
@@ -40,7 +40,7 @@ positional-arg --required --var=value value
 # Expressions to operate on the value.
 rest-arg --var=exprArgs jval-exprs
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 if [[ ${filePath} != '' ]]; then
     if [[ ${value} != '' ]]; then

--- a/scripts/lib/bashy-basics/jlength
+++ b/scripts/lib/bashy-basics/jlength
@@ -19,7 +19,7 @@ define-usage --with-help $'
 # JSON value.
 positional-arg --required --var=value json-value
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/jstring
+++ b/scripts/lib/bashy-basics/jstring
@@ -20,7 +20,7 @@ define-usage --with-help $'
 # Strings to convert
 rest-arg --var=values string
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/jval
+++ b/scripts/lib/bashy-basics/jval
@@ -122,7 +122,7 @@ function parse-rest {
     fi
 }
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/ls-files
+++ b/scripts/lib/bashy-basics/ls-files
@@ -113,7 +113,7 @@ function parse-rest {
     fi
 }
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/rsync-local
+++ b/scripts/lib/bashy-basics/rsync-local
@@ -44,7 +44,7 @@ opt-value --call='{ excludeOpts+=("--exclude=$1") }' exclude
 # Paths to copy from/to.
 rest-arg --var=paths paths
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 if (( ${#paths} < 2 )); then
     error-msg 'Must specify at least two paths.'

--- a/scripts/lib/bashy-basics/tempy/mkdir
+++ b/scripts/lib/bashy-basics/tempy/mkdir
@@ -24,7 +24,7 @@ define-usage --with-help $'
 # Prefix.
 opt-value --var=prefix --init='tmp-' prefix
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/tempy/name
+++ b/scripts/lib/bashy-basics/tempy/name
@@ -26,7 +26,7 @@ define-usage --with-help $'
 # Prefix.
 opt-value --var=prefix --init='tmp-' prefix
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/timey/now-stamp
+++ b/scripts/lib/bashy-basics/timey/now-stamp
@@ -29,7 +29,7 @@ opt-value --var=prefix prefix
 # Suffix.
 opt-value --var=suffix suffix
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/timey/print
+++ b/scripts/lib/bashy-basics/timey/print
@@ -38,7 +38,7 @@ positional-arg --required --var=time time
 # Output format.
 positional-arg --var=format --filter='/^[+]/' format
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-basics/timey/secs
+++ b/scripts/lib/bashy-basics/timey/secs
@@ -28,7 +28,7 @@ opt-value --var=inputType --init='secs' --enum='secs rfc822' input
 # Time value to parse.
 positional-arg --required --var=time time
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-core/_default-run
+++ b/scripts/lib/bashy-core/_default-run
@@ -39,7 +39,7 @@ positional-arg --var=command command
 # The original command arguments, including any subcommands and other arguments.
 rest-arg --var=origArgs args
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -266,8 +266,10 @@ function post-process-args-call {
 }
 
 # Processes all of the given arguments, according to the configured handlers.
-# Returns non-zero if there is trouble parsing options or if any handler returns
-# non-zero.
+# Returns normally upon successful processing. If there is any trouble parsing
+# (including if there were errors during argument/option declaration), this
+# prints the short form of the `usage` message (if `usage` is available) and
+# then exits the process entirely with a non-zero code.
 function process-args {
     local _argproc_error=0
     local _argproc_s

--- a/scripts/lib/bashy-core/helpy/print-all-commands
+++ b/scripts/lib/bashy-core/helpy/print-all-commands
@@ -28,7 +28,7 @@ opt-value --var=unitNames --filter='/^[-_.a-zA-Z0-9 ]+$/' units
 # Prefix string.
 opt-value --var=prefix prefix
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-core/helpy/print-subcommands
+++ b/scripts/lib/bashy-core/helpy/print-subcommands
@@ -23,7 +23,7 @@ positional-arg --required --var=cmdName --filter='/^[-a-z]/' command
 # Subcommands if any.
 rest-arg --var=subWords --filter='/^[-a-z]/' subcommands
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-core/helpy/print-usage
+++ b/scripts/lib/bashy-core/helpy/print-usage
@@ -33,9 +33,9 @@ define-usage --with-help $'
     --short
       Prints a short version of the <message>, intended to be the coda on some
       other error message. This only prints double-newline delimited sections
-      whose first line starts with the value of `$${name}`. In addition, it
-      prepends an extra newline at the start. Note: For this to work as intended,
-      always put a double-newline after each command summary section.
+      whose first line starts with the value of `$${name}`. Note: For this to
+      work as intended, always put a double-newline after each command summary
+      section.
 '
 
 # Command name.
@@ -128,7 +128,6 @@ END {
     message = vars["message"];
 
     if (short) {
-        print "";
         print shorten(message, vars["name"]);
     } else {
         print message;

--- a/scripts/lib/bashy-core/helpy/print-usage
+++ b/scripts/lib/bashy-core/helpy/print-usage
@@ -47,7 +47,7 @@ opt-toggle --var=short short
 # Usage message to print.
 positional-arg --required --var=message message
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-core/misc.sh
+++ b/scripts/lib/bashy-core/misc.sh
@@ -19,12 +19,8 @@ _bashy_usageMessage=''
 #
 
 # Defines a standard-form `usage` function, optionally adding standardized help
-# options. When `usage` is defined with this, any non-zero pending exit code
-# (`$?`) becomes a process exit, so, for example, it is possible to say
-# something like `do-something || usage --short`, and know that that will exit
-# the process on error. With option `--with-help`, this defines standard help
-# options `--help` and short form `-h`, and appends help-for-help to the
-# description.
+# options. With option `--with-help`, this defines standard help options
+# `--help` and short form `-h`, and appends help-for-help to the description.
 function define-usage {
     local withHelp=0
     if [[ $1 == --with-help ]]; then
@@ -49,11 +45,7 @@ function define-usage {
     fi
 
     local func=$'function usage {
-        local exitCode="$?"
         lib helpy print-usage --name="$(this-cmd-name)" "$@" "${_bashy_usageMessage}"
-        if (( exitCode != 0 )); then
-            exit "${exitCode}"
-        fi
     }'
 
     eval "${func}"

--- a/scripts/lib/bashy-core/misc.sh
+++ b/scripts/lib/bashy-core/misc.sh
@@ -21,7 +21,7 @@ _bashy_usageMessage=''
 # Defines a standard-form `usage` function, optionally adding standardized help
 # options. When `usage` is defined with this, any non-zero pending exit code
 # (`$?`) becomes a process exit, so, for example, it is possible to say
-# something like `process-args "$@" || usage --short`, and know that that exit
+# something like `do-something || usage --short`, and know that that will exit
 # the process on error. With option `--with-help`, this defines standard help
 # options `--help` and short form `-h`, and appends help-for-help to the
 # description.

--- a/scripts/lib/bashy-net/cidr-calc
+++ b/scripts/lib/bashy-net/cidr-calc
@@ -60,7 +60,7 @@ positional-arg --required --var=command command
 # Command arguments.
 rest-arg --var=args args
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-net/extract-public-key
+++ b/scripts/lib/bashy-net/extract-public-key
@@ -37,7 +37,7 @@ opt-value --var=outputStyle --init=public-key \
 # File path.
 positional-arg --init='/dev/stdin' --var=path file-path
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-net/generate-private-key
+++ b/scripts/lib/bashy-net/generate-private-key
@@ -35,7 +35,7 @@ opt-value --required --var=type \
 # Where to output.
 opt-value --var=out --init='/dev/stdout' out
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-node/node-project/build-main-module
+++ b/scripts/lib/bashy-node/node-project/build-main-module
@@ -61,7 +61,7 @@ opt-toggle --var=runNpmInstallScripts unsafely-run-npm-install-scripts
 # Project name.
 positional-arg --filter='/^[-a-z0-9]+$/' --var=projectName project-name
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-node/node-project/find-module-dependencies
+++ b/scripts/lib/bashy-node/node-project/find-module-dependencies
@@ -48,7 +48,7 @@ require-exactly-one-arg-of modules-dir modules-dirs
 # The module to start at.
 positional-arg --required --var=moduleName module-name
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-node/node-project/fix-package-json
+++ b/scripts/lib/bashy-node/node-project/fix-package-json
@@ -20,7 +20,7 @@ define-usage --with-help $'
 # Specific paths to process
 rest-arg --var=files --filter=/./ file
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/lib/bashy-node/node-project/sort-imports
+++ b/scripts/lib/bashy-node/node-project/sort-imports
@@ -21,7 +21,7 @@ define-usage --with-help $'
 # Specific paths to process
 rest-arg --var=files --filter=/./ file
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/scripts/ubik
+++ b/scripts/ubik
@@ -27,7 +27,7 @@ positional-arg --var=cmdName command
 # The actual command arguments.
 rest-arg --var=args args
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/tests/02-core/02-define-usage/01-usage-call/expect.md
+++ b/tests/02-core/02-define-usage/01-usage-call/expect.md
@@ -1,12 +1,15 @@
 ## short
 
+### stdout
+```
+Done.
+```
+
 ### stderr
 ```
-This is not actually an error! (But we can pretend.)
 the-cmd -- This is the short
 help for the command.
 the-cmd another-option-variant
-(no exit expected; should see this)
 ```
 
 ### exit: 0
@@ -14,6 +17,11 @@ the-cmd another-option-variant
 - - - - - - - - - -
 
 ## long
+
+### stdout
+```
+Done.
+```
 
 ### stderr
 ```
@@ -25,7 +33,6 @@ This is the longer help.
 the-cmd another-option-variant
 
 And more help about that.
-(no exit expected; should see this)
 ```
 
 ### exit: 0
@@ -34,26 +41,34 @@ And more help about that.
 
 ## error 1
 
+### stdout
+```
+Done.
+```
+
 ### stderr
 ```
-This is an error!
 the-cmd -- This is the short
 help for the command.
 the-cmd another-option-variant
 ```
 
-### exit: 1
+### exit: 0
 
 - - - - - - - - - -
 
 ## error 99
 
+### stdout
+```
+Done.
+```
+
 ### stderr
 ```
-This is an error!
 the-cmd -- This is the short
 help for the command.
 the-cmd another-option-variant
 ```
 
-### exit: 99
+### exit: 0

--- a/tests/02-core/02-define-usage/01-usage-call/expect.md
+++ b/tests/02-core/02-define-usage/01-usage-call/expect.md
@@ -3,7 +3,6 @@
 ### stderr
 ```
 This is not actually an error! (But we can pretend.)
-
 the-cmd -- This is the short
 help for the command.
 the-cmd another-option-variant
@@ -38,7 +37,6 @@ And more help about that.
 ### stderr
 ```
 This is an error!
-
 the-cmd -- This is the short
 help for the command.
 the-cmd another-option-variant
@@ -53,7 +51,6 @@ the-cmd another-option-variant
 ### stderr
 ```
 This is an error!
-
 the-cmd -- This is the short
 help for the command.
 the-cmd another-option-variant

--- a/tests/02-core/02-define-usage/01-usage-call/the-cmd
+++ b/tests/02-core/02-define-usage/01-usage-call/the-cmd
@@ -25,16 +25,16 @@ what="$1"
 case "${what}" in
     long)
         usage
-        echo 1>&2 '(no exit expected; should see this)'
         ;;
     short)
-        echo 1>&2 'This is not actually an error! (But we can pretend.)'
         usage --short
-        echo 1>&2 '(no exit expected; should see this)'
         ;;
     *)
-        echo 1>&2 'This is an error!'
+        # Old behavior was that `usage` would magically `exit` if `$?` was
+        # non-zero upon entry. This test now verifies that it no longer does
+        # that.
         (exit "${what}") || usage --short
-        echo 1>&2 '(exit expected; should not see this)'
         ;;
 esac
+
+echo 'Done.'

--- a/tests/02-core/02-define-usage/02-with-help/the-cmd
+++ b/tests/02-core/02-define-usage/02-with-help/the-cmd
@@ -16,6 +16,6 @@ define-usage --with-help $'
     This is the longer help.
 '
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 echo 'Finished.'

--- a/tests/02-core/03-arg-processor/01-nothing-defined/the-cmd
+++ b/tests/02-core/03-arg-processor/01-nothing-defined/the-cmd
@@ -15,6 +15,6 @@ define-usage $'
     This is a test command.
 '
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 echo 'Success!'

--- a/tests/02-core/03-arg-processor/02-one-required-positional/the-cmd
+++ b/tests/02-core/03-arg-processor/02-one-required-positional/the-cmd
@@ -17,6 +17,6 @@ define-usage $'
 
 positional-arg --required --var=theName zongo
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 printf 'Value: %q\n' "${theName}"

--- a/tests/02-core/03-arg-processor/03-one-optional-positional/the-cmd
+++ b/tests/02-core/03-arg-processor/03-one-optional-positional/the-cmd
@@ -17,6 +17,6 @@ define-usage $'
 
 positional-arg --var=theName --init=zorch zongo
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 printf 'Value: %q\n' "${theName}"

--- a/tests/02-core/03-arg-processor/04-positional-req-opt/the-cmd
+++ b/tests/02-core/03-arg-processor/04-positional-req-opt/the-cmd
@@ -19,7 +19,7 @@ positional-arg --required --var=yesArg avec-yes
 
 positional-arg --var=someValue some-value
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 printf 'avec-yes: %q\n' "${yesArg}"
 printf 'some-value: %q\n' "${someValue}"

--- a/tests/02-core/03-arg-processor/90-init-cross-checks/the-cmd
+++ b/tests/02-core/03-arg-processor/90-init-cross-checks/the-cmd
@@ -25,6 +25,6 @@ opt-value --init=x --call=func1 beep
 opt-choice --init=x --call=func2 bomp blump
 positional-arg --init=x --call=func3 plomp
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 echo 'Nopers.'

--- a/tests/02-core/03-arg-processor/91-unknown-declaration-opts/the-cmd
+++ b/tests/02-core/03-arg-processor/91-unknown-declaration-opts/the-cmd
@@ -27,6 +27,6 @@ opt-value -zonk --var=v x
 opt-value ---zonk --var=v x
 opt-value --Zomg --var=v x
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 echo 'Nopers.'

--- a/tests/02-core/03-arg-processor/92-call-or-var/the-cmd
+++ b/tests/02-core/03-arg-processor/92-call-or-var/the-cmd
@@ -22,6 +22,6 @@ opt-toggle boop
 positional-arg --filter='/boop/' some-position
 rest-arg --filter='/x/' the-rest
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 echo 'Nopers.'

--- a/tests/02-core/03-arg-processor/93-spec-arg-problems/the-cmd
+++ b/tests/02-core/03-arg-processor/93-spec-arg-problems/the-cmd
@@ -49,6 +49,6 @@ opt-choice --var=var1 florp foo=x bar
 positional-arg --var=var2 fleep=123
 rest-arg --var=var3 floop=xyz
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 echo 'Nopers.'

--- a/tests/02-core/03-arg-processor/94-duplicate-argument/the-cmd
+++ b/tests/02-core/03-arg-processor/94-duplicate-argument/the-cmd
@@ -31,6 +31,6 @@ rest-arg --var=var2 a-rest
 rest-arg --var=var3 different-name
 
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 echo 'Nopers.'

--- a/tests/02-core/03-arg-processor/95-incorrect-required/the-cmd
+++ b/tests/02-core/03-arg-processor/95-incorrect-required/the-cmd
@@ -20,6 +20,6 @@ opt-toggle --required --var=var1 some-toggle
 rest-arg --required --var=var1 some-rest
 
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 echo 'Nopers.'

--- a/tests/run-all
+++ b/tests/run-all
@@ -16,7 +16,7 @@ define-usage --with-help $'
     Runs all the tests.
 '
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #

--- a/tests/run-all
+++ b/tests/run-all
@@ -38,16 +38,29 @@ if [[ ${allRunScripts[0]} == 'error' ]]; then
     exit 1
 fi
 
-errors=0
+errors=()
 for run in "${allRunScripts[@]}"; do
-    "${testsDir}/run-one" "${run%/run}" \
-    || (( errors++ ))
+    testName="${run%/run}"
+    "${testsDir}/run-one" "${testName}" \
+    || errors+=("${testName}")
 done
 
-if (( errors == 0 )); then
+errorCount="${#errors[@]}"
+
+echo ''
+
+if (( errorCount == 0 )); then
     echo 'All passed. Yay!'
 else
-    (( errors == 1 )) && noun=error || noun=errors
-    echo "${errors} ${noun}. Alas."
+    echo 'Problems with:'
+
+    for e in "${errors[@]}"; do
+        echo "  ${e}"
+    done
+
+    (( errorCount == 1 )) && noun=error || noun=errors
+    echo ''
+    echo "${errorCount} ${noun}. Alas."
+
     exit 1
 fi

--- a/tests/run-one
+++ b/tests/run-one
@@ -36,7 +36,7 @@ opt-toggle --var=doUpdate update
 # The test to run.
 positional-arg --required --var=testName --filter='/[0-9][-/a-z0-9]*$/' test-name
 
-process-args "$@" || usage --short
+process-args "$@" || exit "$?"
 
 
 #


### PR DESCRIPTION
This PR does a few things around error cases of `process-args` and `usage`:

* Makes `usage` no longer "magically" exit when `$?` is non-zero upon being called.
* Drops the extra newline before a `usage --short` message.
* Makes `process-args` print out `usage --short` when reporting errors (along with that extra newline which used to be in `usage --short`).