### PR TITLE
`opt-alias`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Other notable changes:
 * `bashy-core`:
   * `arg-processor`:
     * Tightened up error checking and reporting.
+    * Added `opt-alias` to allow for expansion of single no-value options into
+      multiple options (including with values). Used underlying facility to
+      rework implementation of single-character short options.
     * Added multi-value option syntax `--opt-name[]=...`, along with helper
       function `values` for use sites.
   * `define-usage`: New option `--with-help` to help reduce boilerplate.

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -1023,6 +1023,7 @@ function _argproc_statements-from-args {
                         eval 2>/dev/null "values=(${value})" || {
                             error-msg "Invalid multi-value syntax for option --${name}:"
                             error-msg "  ${value}"
+                            argError=1
                         }
                         _argproc_statements+=(
                             "${handler} $(_argproc_quote "${values[@]}")")

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -555,7 +555,9 @@ function _argproc_define-alias-arg {
     }'
 
     if [[ ${abbrevChar} != '' ]]; then
-        _argproc_define-abbrev "${abbrevChar}" "${specName}"
+        eval 'function _argproc:alias-short-'"${abbrevChar}"' {
+            '"${handlerName}"' "$@"
+        }'
     fi
 }
 

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -1006,8 +1006,8 @@ function _argproc_statements-from-args {
             name="${BASH_REMATCH[1]}"
             assign="${BASH_REMATCH[3]}"
             value="${BASH_REMATCH[4]}"
-            handler="_argproc:long-${name}"
-            if declare -F "${handler}" >/dev/null; then
+            if handler="_argproc:long-${name}" \
+                    && declare -F "${handler}" >/dev/null; then
                 case "${assign}" in
                     '')
                         # No-value option.

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -1032,9 +1032,18 @@ function _argproc_statements-from-args {
                 esac
             elif handler="_argproc:alias-${name}" \
                     && declare -F "${handler}" >/dev/null; then
+                # Alias option; must not be passed any values.
                 if [[ ${assign} == '' ]]; then
-                    # TODO
-                    :
+                    # Parse the output of `handler` into new options, and
+                    # "unshift" them onto `$@`.
+                    if eval 2>/dev/null "values=($("\${handler}"))"; then
+                        shift # Shift the alias option away.
+                        set -- shifted-away-below "${values[@]}" "$@"
+                    else
+                        error-msg "Invalid multi-value syntax for option --${name}:"
+                        error-msg "  ${value}"
+                        argError=1
+                    fi
                 else
                     error-msg "Cannot pass values to alias option: --${name}"
                     argError=1

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -1007,10 +1007,7 @@ function _argproc_statements-from-args {
             assign="${BASH_REMATCH[3]}"
             value="${BASH_REMATCH[4]}"
             handler="_argproc:long-${name}"
-            if ! declare -F "${handler}" >/dev/null; then
-                error-msg "Unknown option: --${name}"
-                argError=1
-            else
+            if declare -F "${handler}" >/dev/null; then
                 case "${assign}" in
                     '')
                         # No-value option.
@@ -1031,6 +1028,9 @@ function _argproc_statements-from-args {
                             "${handler} $(_argproc_quote "${values[@]}")")
                         ;;
                 esac
+            else
+                error-msg "Unknown option: --${name}"
+                argError=1
             fi
         elif [[ $arg =~ ^-([a-zA-Z0-9]+)$ ]]; then
             # Short-form option.

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -116,7 +116,7 @@ function opt-action {
 # expanded options). In fact, _no_ options are available when defining an alias.
 function opt-alias {
     local args=("$@")
-    _argproc_janky-args --multi-arg call \
+    _argproc_janky-args --multi-arg \
     || return 1
 
     local specName=''

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -1112,10 +1112,7 @@ function _argproc_statements-from-args {
             while [[ ${arg} =~ ^(.)(.*)$ ]]; do
                 name="${BASH_REMATCH[1]}"
                 arg="${BASH_REMATCH[2]}"
-                if handler="_argproc:abbrev-${name}" \
-                        && declare -F "${handler}" >/dev/null; then
-                    _argproc_statements+=("${handler}")
-                elif handler="_argproc:short-alias-${name}" \
+                if handler="_argproc:short-alias-${name}" \
                         && declare -F "${handler}" >/dev/null; then
                     # Parse the output of `handler` into new options, and
                     # "unshift" them onto `$@`.

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -532,22 +532,26 @@ function _argproc_define-alias-arg {
 
     local specName="$1"
     local abbrevChar="$2"
+    shift 2
+    local args=("$@")
 
     _argproc_set-arg-description "${specName}" alias || return 1
 
     local desc="$(_argproc_arg-description "${specName}")"
     local handlerName="_argproc:alias-${specName}"
-    local handlerBody="$(
-        _argproc_handler-body "${specName}" '' "${callFunc}" "${varName}"
-    )"
+    local handlerBody=()
+
+    local a
+    for a in "${args[@]}"; do
+        handlerBody+=(printf '%q\n' "$(_argproc_quote "${a}")")
+    done
 
     eval 'function '"${handlerName}"' {
         if (( $# > 0 )); then
             error-msg "Value not allowed for '"${desc}"'."
             return 1
         fi
-        set '"${value}"'
-        '"${handlerBody}"'
+        '"${handlerBody[@]}"'
     }'
 
     if [[ ${abbrevChar} != '' ]]; then

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -17,7 +17,7 @@
 # `<value>` are always optional and (independently) sometimes prohibited,
 # depending on the definition function.
 #
-# The public argument-defining functions also all allow these options, of which
+# Most public argument-defining functions also all allow these options, of which
 # at least one must be used. When both are used, the `--call` is performed
 # first, and then the `--var` setting.
 # present, evaluation order is filter then call then variable setting.
@@ -106,6 +106,22 @@ function opt-action {
         # Set up the variable initializer.
         _argproc_initStatements+=("${optVar}=$(_argproc_quote "${optDefault}")")
     fi
+}
+
+# Declares an "alias" option, which expands into an arbitrary set of other
+# options. On a commandline, alias options do not accept values (because values,
+# if any, are provided in the expansion). Similarly, and unlike most of the
+# argument-definining functions, alias options cannot be specified with either
+# `--call` or `--var` (because any calls or variable setting is done with the
+# expanded options). In fact, _no_ options are available when defining an alias.
+function opt-alias {
+    local args=("$@")
+    _argproc_janky-args --multi-arg call \
+    || return 1
+
+    # TODO!
+    error-msg TODO
+    return 1
 }
 
 # Declares a "choice" option set, consisting of one or more options. On a

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -1015,10 +1015,11 @@ function _argproc_statements-from-args {
             else
                 _argproc_statements+=("${handler} $(_argproc_quote "${value}")")
             fi
-        elif [[ ${arg} =~ ^--([-a-zA-Z0-9]+)'[]='(.*)$ ]]; then
+        elif [[ ${arg} =~ ^--([-a-zA-Z0-9]+)(('[]=')(.*))$ ]]; then
             # Long-form multi-value option.
             name="${BASH_REMATCH[1]}"
-            value="${BASH_REMATCH[2]}"
+            assign="${BASH_REMATCH[3]}"
+            value="${BASH_REMATCH[4]}"
             handler="_argproc:long-${name}"
             if ! declare -F "${handler}" >/dev/null; then
                 error-msg "Unknown option: --${name}"

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -515,8 +515,8 @@ function _argproc_define-abbrev {
     local abbrevChar="$1"
     local specName="$2"
 
-    eval 'function _argproc:abbrev-'"${abbrevChar}"' {
-        _argproc:long-'"${specName}"' "$@"
+    eval 'function _argproc:short-alias-'"${abbrevChar}"' {
+        echo --'"${specName}"'
     }'
 }
 
@@ -1091,7 +1091,7 @@ function _argproc_statements-from-args {
                 if [[ ${assign} == '' ]]; then
                     # Parse the output of `handler` into new options, and
                     # "unshift" them onto `$@`.
-                    if eval 2>/dev/null "values=($("\${handler}"))"; then
+                    if eval 2>/dev/null "values=($("${handler}"))"; then
                         shift # Shift the alias option away.
                         set -- shifted-away-below "${values[@]}" "$@"
                     else
@@ -1119,7 +1119,7 @@ function _argproc_statements-from-args {
                         && declare -F "${handler}" >/dev/null; then
                     # Parse the output of `handler` into new options, and
                     # "unshift" them onto `$@`.
-                    if eval 2>/dev/null "values=($("\${handler}"))"; then
+                    if eval 2>/dev/null "values=($("${handler}"))"; then
                         shift # Shift the alias option away.
                         set -- shifted-away-below "${values[@]}" "$@"
                     else

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -539,19 +539,12 @@ function _argproc_define-alias-arg {
 
     local desc="$(_argproc_arg-description "${specName}")"
     local handlerName="_argproc:alias-${specName}"
-    local handlerBody=()
-
-    local a
-    for a in "${args[@]}"; do
-        handlerBody+=(printf '%q\n' "$(_argproc_quote "${a}")")
-    done
-
     eval 'function '"${handlerName}"' {
         if (( $# > 0 )); then
             error-msg "Value not allowed for '"${desc}"'."
             return 1
         fi
-        '"${handlerBody[@]}"'
+        printf "%q\\n" '"$(_argproc_quote "${args[@]}")"'
     }'
 
     if [[ ${abbrevChar} != '' ]]; then

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -1113,15 +1113,15 @@ function _argproc_statements-from-args {
             while [[ ${arg} =~ ^(.)(.*)$ ]]; do
                 name="${BASH_REMATCH[1]}"
                 arg="${BASH_REMATCH[2]}"
-                handler="_argproc:abbrev-${name}"
-                if ! declare -F "${handler}" >/dev/null; then
+                if handler="_argproc:abbrev-${name}" \
+                        && declare -F "${handler}" >/dev/null; then
+                    _argproc_statements+=("${handler}")
+                else
                     error-msg "Unknown option: -${name}"
                     argError=1
                     # Break, to avoid spewing a ton of errors in case of a pilot
                     # error along the lines of `-longOptionName`.
                     break
-                else
-                    _argproc_statements+=("${handler}")
                 fi
             done
         else

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -986,7 +986,7 @@ function _argproc_set-arg-description {
 # read.
 function _argproc_statements-from-args {
     local argError=0
-    local arg handler name value values
+    local arg handler name assign value values
 
     # This is used for required-argument checking.
     _argproc_statements+=($'local _argproc_receivedArgNames=\'\'')
@@ -1001,19 +1001,19 @@ function _argproc_statements-from-args {
         elif [[ ${arg} == '' || ${arg} =~ ^-[0-9]*$ || ${arg} =~ ^[^-] ]]; then
             # Non-option argument.
             break
-        elif [[ ${arg} =~ ^--([-a-zA-Z0-9]+)(=.*)?$ ]]; then
+        elif [[ ${arg} =~ ^--([-a-zA-Z0-9]+)((=)(.*))?$ ]]; then
             # Long-form no- or single-value option.
             name="${BASH_REMATCH[1]}"
-            value="${BASH_REMATCH[2]}"
+            assign="${BASH_REMATCH[3]}"
+            value="${BASH_REMATCH[4]}"
             handler="_argproc:long-${name}"
             if ! declare -F "${handler}" >/dev/null; then
                 error-msg "Unknown option: --${name}"
                 argError=1
-            elif [[ ${value} == '' ]]; then
+            elif [[ ${assign} == '' ]]; then
                 _argproc_statements+=("${handler}")
             else
-                # `:1` to drop the `=` from the start of `value`.
-                _argproc_statements+=("${handler} $(_argproc_quote "${value:1}")")
+                _argproc_statements+=("${handler} $(_argproc_quote "${value}")")
             fi
         elif [[ ${arg} =~ ^--([-a-zA-Z0-9]+)'[]='(.*)$ ]]; then
             # Long-form multi-value option.

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -978,7 +978,7 @@ function _argproc_set-arg-description {
 
 # Builds up a list of statements to evaluate, based on the given arguments. It
 # is stored in the variable `_argproc_statements`, which is assumed to be
-# declared by its caller.
+# declared `local` by its caller.
 #
 # Note: This arrangement, where argument parsing is done in a separate
 # function and as a separate pass from evaluation, makes it possible to use

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -1020,13 +1020,14 @@ function _argproc_statements-from-args {
                         ;;
                     '[]=')
                         # Multi-value option. Parse the value into elements.
-                        eval 2>/dev/null "values=(${value})" || {
+                        if eval 2>/dev/null "values=(${value})"; then
+                            _argproc_statements+=(
+                                "${handler} $(_argproc_quote "${values[@]}")")
+                        else
                             error-msg "Invalid multi-value syntax for option --${name}:"
                             error-msg "  ${value}"
                             argError=1
-                        }
-                        _argproc_statements+=(
-                            "${handler} $(_argproc_quote "${values[@]}")")
+                        fi
                         ;;
                 esac
             elif handler="_argproc:alias-${name}" \

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -1029,6 +1029,15 @@ function _argproc_statements-from-args {
                             "${handler} $(_argproc_quote "${values[@]}")")
                         ;;
                 esac
+            elif handler="_argproc:alias-${name}" \
+                    && declare -F "${handler}" >/dev/null; then
+                if [[ ${assign} == '' ]]; then
+                    # TODO
+                    :
+                else
+                    error-msg "Cannot pass values to alias option: --${name}"
+                    argError=1
+                fi
             else
                 error-msg "Unknown option: --${name}"
                 argError=1

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -535,7 +535,7 @@ function _argproc_define-alias-arg {
     shift 2
     local args=("$@")
 
-    _argproc_set-arg-description "${specName}" alias || return 1
+    _argproc_set-arg-description "${specName}" option || return 1
 
     local desc="$(_argproc_arg-description "${specName}")"
     local handlerName="_argproc:alias-${specName}"

--- a/tests/02-core/02-arg-processor/12-optmulti/expect.md
+++ b/tests/02-core/02-arg-processor/12-optmulti/expect.md
@@ -154,3 +154,56 @@ Count: 5
 ```
 
 ### exit: 0
+
+- - - - - - - - - -
+
+## passed multi-value option, with invalid multi-value syntax #1
+
+### stderr
+```
+the-cmd: Invalid multi-value syntax for option --items:
+  one "two
+
+the-cmd -- test command
+```
+
+### exit: 1
+
+- - - - - - - - - -
+
+## passed multi-value option, with invalid multi-value syntax #2
+
+### stderr
+```
+the-cmd: Invalid multi-value syntax for option --items:
+  a ; b
+
+the-cmd -- test command
+```
+
+### exit: 1
+
+- - - - - - - - - -
+
+## passed multi-value option, with invalid multi-value syntax #3
+
+### stdout
+```
+Count: 0
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed multi-value option, with invalid multi-value syntax #4
+
+### stderr
+```
+the-cmd: Invalid multi-value syntax for option --items:
+  d|e f&g
+
+the-cmd -- test command
+```
+
+### exit: 1

--- a/tests/02-core/02-arg-processor/12-optmulti/run
+++ b/tests/02-core/02-arg-processor/12-optmulti/run
@@ -44,3 +44,15 @@ call-and-log-as-test 'passed multi-value option, two values' \
 
 call-and-log-as-test 'passed multi-value option, four values, omnibus' \
     "${cmd}" --items[]=$'one "two" \'three four\' $\'five & six\' \#7\(8\)9'
+
+call-and-log-as-test 'passed multi-value option, with invalid multi-value syntax #1' \
+    "${cmd}" --items[]=$'one "two'
+
+call-and-log-as-test 'passed multi-value option, with invalid multi-value syntax #2' \
+    "${cmd}" --items[]=$'a ; b'
+
+call-and-log-as-test 'passed multi-value option, with invalid multi-value syntax #3' \
+    "${cmd}" --items[]=$'$c'
+
+call-and-log-as-test 'passed multi-value option, with invalid multi-value syntax #4' \
+    "${cmd}" --items[]=$'d|e f&g'

--- a/tests/02-core/02-arg-processor/18-alias/expect.md
+++ b/tests/02-core/02-arg-processor/18-alias/expect.md
@@ -1,0 +1,179 @@
+## passed alias to action
+
+### stdout
+```
+action: 1
+multi: ()
+toggle: 0
+value: ''
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed alias to multi
+
+### stdout
+```
+action: 0
+multi: (one two three)
+toggle: 0
+value: ''
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed alias to toggle
+
+### stdout
+```
+action: 0
+multi: ()
+toggle: 1
+value: ''
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed alias to no-toggle
+
+### stdout
+```
+action: 0
+multi: ()
+toggle: 0
+value: ''
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed alias to value
+
+### stdout
+```
+action: 0
+multi: ()
+toggle: 0
+value: one
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed short-alias to value
+
+### stdout
+```
+action: 0
+multi: ()
+toggle: 0
+value: one
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed alias to action and toggle
+
+### stdout
+```
+action: 1
+multi: ()
+toggle: 1
+value: ''
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed short-alias to action and toggle
+
+### stdout
+```
+action: 1
+multi: ()
+toggle: 1
+value: ''
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed alias to action, toggle, and value
+
+### stdout
+```
+action: 1
+multi: ()
+toggle: 1
+value: two
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed alias to value and no-toggle
+
+### stdout
+```
+action: 0
+multi: ()
+toggle: 0
+value: 3
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed alias to value and multi
+
+### stdout
+```
+action: 0
+multi: (yes no maybe\?)
+toggle: 0
+value: florp
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed alias to value, spaces in expansion
+
+### stdout
+```
+action: 0
+multi: ()
+toggle: 0
+value: this\ is\ fun
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## passed alias to value, special characters in expansion
+
+### stdout
+```
+action: 0
+multi: ()
+toggle: 0
+value: y\$e\&s\|\!
+```
+
+### exit: 0

--- a/tests/02-core/02-arg-processor/18-alias/info.md
+++ b/tests/02-core/02-arg-processor/18-alias/info.md
@@ -1,0 +1,1 @@
+Test of alias options.

--- a/tests/02-core/02-arg-processor/18-alias/run
+++ b/tests/02-core/02-arg-processor/18-alias/run
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2022-2023 the Bashy-lib Authors (Dan Bornstein et alia).
+# SPDX-License-Identifier: Apache-2.0
+
+[[ "$(readlink -f "$0")" =~ ^(.*/tests/) ]] && . "${BASH_REMATCH[1]}_test-init.sh" || exit 1
+
+cmd="$(this-cmd-dir)/the-cmd"
+
+call-and-log-as-test 'passed alias to action' \
+    "${cmd}" --do-action
+
+call-and-log-as-test 'passed alias to multi' \
+    "${cmd}" --multi-123
+
+call-and-log-as-test 'passed alias to toggle' \
+    "${cmd}" --do-toggle
+
+# `--toggle` first so that `--do-notog` has a chance to demonstrate correctness.
+call-and-log-as-test 'passed alias to no-toggle' \
+    "${cmd}" --toggle --do-notog
+
+call-and-log-as-test 'passed alias to value' \
+    "${cmd}" --val-1
+
+call-and-log-as-test 'passed short-alias to value' \
+    "${cmd}" -v
+
+call-and-log-as-test 'passed alias to action and toggle' \
+    "${cmd}" --do-act-tog
+
+call-and-log-as-test 'passed short-alias to action and toggle' \
+    "${cmd}" -t
+
+call-and-log-as-test 'passed alias to action, toggle, and value' \
+    "${cmd}" --do-act-tog-val-2
+
+# `--toggle` first so that `--do-notog` has a chance to demonstrate correctness.
+call-and-log-as-test 'passed alias to value and no-toggle' \
+    "${cmd}" --toggle --do-notog-val-3
+
+call-and-log-as-test 'passed alias to value and multi' \
+    "${cmd}" --val-multi
+
+call-and-log-as-test 'passed alias to value, spaces in expansion' \
+    "${cmd}" --val-with-spaces
+
+call-and-log-as-test 'passed alias to value, special characters in expansion' \
+    "${cmd}" --val-with-specials

--- a/tests/02-core/02-arg-processor/18-alias/the-cmd
+++ b/tests/02-core/02-arg-processor/18-alias/the-cmd
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright 2022-2023 the Bashy-lib Authors (Dan Bornstein et alia).
+# SPDX-License-Identifier: Apache-2.0
+
+[[ "$(readlink -f "$0")" =~ ^(.*/tests/) ]] && . "${BASH_REMATCH[1]}_init.sh" || exit 1
+
+
+#
+# Argument parsing
+#
+
+define-usage $'
+    ${name} -- test command
+
+    This is a test command.
+'
+
+opt-action --var=someAction action
+opt-toggle --var=someToggle toggle
+opt-value --var=someValue value
+opt-multi --var=someMulti multi
+
+opt-alias do-action --action
+opt-alias multi-123 --multi[]='one two three'
+opt-alias do-toggle --toggle
+opt-alias do-notog --no-toggle
+opt-alias val-1/v --value=one
+opt-alias do-act-tog/t --action --toggle
+opt-alias do-act-tog-val-2 --value=two --toggle --action
+opt-alias do-notog-val-3 --no-toggle --value=3
+opt-alias val-multi --value=florp --multi[]='yes no "maybe?"'
+opt-alias val-with-spaces --value='this is fun'
+opt-alias val-with-specials --value='y$e&s|!'
+
+process-args "$@" || exit "$?"
+
+printf 'action: %q\n' "${someAction}"
+
+if (( ${#someMulti[@]} == 0 )); then
+    printf 'multi: ()\n'
+else
+    printf 'multi: ('
+    printf '%q' "${someMulti[0]}"
+    unset someMulti[0]
+    printf ' %q' "${someMulti[@]}"
+    printf ')\n'
+fi
+
+printf 'toggle: %q\n' "${someToggle}"
+printf 'value: %q\n' "${someValue}"


### PR DESCRIPTION
This PR adds `opt-alias`, to define alias options, which lets one define a single valueless option, e.g. `--some-opt` to expand into a series of other options.

This is, in a way, a generalization over `opt-choice`, and I think existing uses of `opt-choice` can be migrated to this.