### PR TITLE
`--enum` cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ Breaking changes:
 * `bashy-core`:
   * `arg-processor`:
     * Tightened up syntax for passing multi-value arguments.
-    * Renamed `--eval=` to `--eval[]=`, to be the same as how options defined by
-      the system work.
+    * Reworked `--eval` to be a multi-value option in the same way that the
+      system lets clients define them. That is, it's now `--enum[]=` instead
+      of `--enum=`.
 
 Other notable changes:
 * `bashy-core`:

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -666,19 +666,23 @@ function _argproc_filter-call {
     local filter="$2"
     shift 2
 
-    local definedFunc=0
-    if [[ ${filter} =~ ^\{(.*)\}$ ]]; then
-        # Kinda gross, but this makes it easy to call the filter code block.
-        eval "function _argproc_filter-call:inner {
+    # Kinda gross, but converting a non-call form to a function makes the
+    # evaluation much more straightforward.
+    local definedFunc=1 filterCall='_argproc_filter-call:inner'
+    if [[ ${filter} =~ ^/(.*)/$ ]]; then
+        : #TODO
+    elif [[ ${filter} =~ ^\{(.*)\}$ ]]; then
+        eval "function ${filterCall} {
             ${BASH_REMATCH[1]}
         }"
-        filter='_argproc_filter-call:inner'
-        definedFunc=1
+    else
+        definedFunc=0
+        filterCall="${filter}"
     fi
 
     local arg result error=0
     for arg in "$@"; do
-        if ! result=("$("${filter}" "${arg}")"); then
+        if ! result=("$("${filterCall}" "${arg}")"); then
             error-msg "Invalid value for ${desc}: ${arg}"
             error=1
             break
@@ -687,7 +691,7 @@ function _argproc_filter-call {
     done
 
     if (( definedFunc )); then
-        unset -f _argproc_filter-call:inner
+        unset -f "${filterCall}"
     fi
 
     return "${error}"

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -35,7 +35,8 @@
 #   is rejected. Note: The filter runs in a subshell, and as such it cannot be
 #   used to affect the global environment of the main script.
 # * `--filter=/<regex>/` -- Matches each argument value against the regex. If
-#   the regex doesn't match, the argument is rejected.
+#   the regex doesn't match, the argument is rejected. The regex must be
+#   non-empty.
 # * `--enum[]=<spec>` -- Matches each argument value against a set of valid
 #   names. `<spec>` must be a non-empty list of values, in the usual multi-value
 #   form accepted by this system, e.g. `--enum[]='yes no "maybe so"'`.
@@ -816,7 +817,7 @@ function _argproc_janky-args {
                     fi
                     ;;
                 filter)
-                    [[ ${value} =~ ^=(/.*/|\{.*\}|[_a-zA-Z][-_:a-zA-Z0-9]*)$ ]] \
+                    [[ ${value} =~ ^=(/.+/|\{.*\}|[_a-zA-Z][-_:a-zA-Z0-9]*)$ ]] \
                     && optFilter="${BASH_REMATCH[1]}" \
                     || argError=1
                     ;;

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -763,11 +763,6 @@ function _argproc_janky-args {
     local gotDefault=0
     local a
 
-    # TEMP: Remove spec mod once use sites are migrated.
-    if [[ ${argSpecs} =~ ' enum[] ' ]]; then
-        argSpecs+='enum '
-    fi
-
     for a in "${args[@]}"; do
         if (( optsDone )); then
             args+=("${a}")
@@ -802,8 +797,7 @@ function _argproc_janky-args {
                     && optDefault="${BASH_REMATCH[1]}" \
                     || argError=1
                     ;;
-                # TEMP: Remove plain `enum` once use sites are migrated.
-                enum|enum[])
+                enum[])
                     if ! _argproc_parse-enum "${value#=}"; then
                         argError=1
                     fi

--- a/scripts/lib/bashy-core/arg-processor.sh
+++ b/scripts/lib/bashy-core/arg-processor.sh
@@ -734,7 +734,7 @@ function _argproc_handler-body {
     if [[ ${callFunc} =~ ^\{(.*)\}$ ]]; then
         # Add a compound statement for the code block.
         result+=(
-            "$(printf '{\n%s\n} || return "$?"\n' "${BASH_REMATCH[1]}")"
+            "$(printf '{\n%s\n} || return "$?"' "${BASH_REMATCH[1]}")"
         )
     elif [[ ${callFunc} != '' ]]; then
         result+=(

--- a/scripts/lib/bashy-core/misc.sh
+++ b/scripts/lib/bashy-core/misc.sh
@@ -127,7 +127,7 @@ function set-array-from-vals {
             printf -v _bashy_print '%q' "${BASH_REMATCH[1]}"
             _bashy_values+=("${_bashy_print}")
             _bashy_value="${BASH_REMATCH[2]}"
-        elif [[ ${_bashy_value} =~ ^(\$\'([^\']|\\\')*\')(.*)$ ]]; then
+        elif [[ ${_bashy_value} =~ ^(\$\'([^\'\\]|\\.)*\')(.*)$ ]]; then
             _bashy_values+=("${BASH_REMATCH[1]}")
             _bashy_value="${BASH_REMATCH[3]}"
         fi

--- a/scripts/lib/bashy-core/misc.sh
+++ b/scripts/lib/bashy-core/misc.sh
@@ -91,6 +91,7 @@ function set-array-from-lines {
 
 # Reverse of `vals`: Assigns parsed elements of the given multi-value string
 # (as produced by `vals` or similar) into the indicated variable, as an array.
+# Values must be separated by at least one whitespace character.
 function set-array-from-vals {
     if (( $# != 2 )); then
         error-msg --file-line=1 'Missing argument(s) to `set-array-from-vals`.'
@@ -102,16 +103,19 @@ function set-array-from-vals {
     local _bashy_name="$1"
     local _bashy_value="$2"
 
+    local _bashy_notsp=$'[^ \n\r\t]'
+    local _bashy_space=$'[ \n\r\t]'
+
     # Trim _ending_ whitespace, and prefix `value` with a space, the latter to
-    # maintain the constraint that values are space-separated.
-    if [[ ${_bashy_value} =~ ^(.*[^ ])' '+$ ]]; then
+    # maintain the constraint that values are whitespace-separated.
+    if [[ ${_bashy_value} =~ ^(.*${bashy_notsp})${_bashy_space}+$ ]]; then
         _bashy_value=" ${BASH_REMATCH[1]}"
     else
         _bashy_value=" ${_bashy_value}"
     fi
 
     local _bashy_values=() _bashy_print
-    while [[ ${_bashy_value} =~ ^' '+([^ ].*)$ ]]; do
+    while [[ ${_bashy_value} =~ ^${_bashy_space}+(${bashy_notsp}.*)$ ]]; do
         _bashy_value="${BASH_REMATCH[1]}"
         if [[ ${_bashy_value} =~ ^([-+=_:./%@a-zA-Z0-9]+)(.*)$ ]]; then
             _bashy_values+=("${BASH_REMATCH[1]}")
@@ -129,7 +133,7 @@ function set-array-from-vals {
         fi
     done
 
-    if ! [[ ${_bashy_value} =~ ^' '*$ ]]; then
+    if ! [[ ${_bashy_value} =~ ^${_bashy_space}*$ ]]; then
         return 1
     fi
 

--- a/tests/02-core/02-arg-processor/19-filter-regex/expect.md
+++ b/tests/02-core/02-arg-processor/19-filter-regex/expect.md
@@ -1,0 +1,119 @@
+## nop filter, empty value
+
+### stderr
+```
+the-cmd: Invalid value for option --nop: 
+
+the-cmd -- test command
+```
+
+### exit: 1
+
+- - - - - - - - - -
+
+## nop filter, non-empty value
+
+### stderr
+```
+the-cmd: Invalid value for option --nop: beep
+
+the-cmd -- test command
+```
+
+### exit: 1
+
+- - - - - - - - - -
+
+## "non-empty" filter, empty value
+
+### stderr
+```
+the-cmd: Invalid value for option --non-empty: 
+
+the-cmd -- test command
+```
+
+### exit: 1
+
+- - - - - - - - - -
+
+## "non-empty" filter, non-empty value
+
+### stdout
+```
+value: beep
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## single-quotes in filter, matching value
+
+### stdout
+```
+value: $'beep \'x\' boop'
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## single-quotes in filter, non-matching value
+
+### stderr
+```
+the-cmd: Invalid value for option --looks-like-sq-string: beep x boop
+
+the-cmd -- test command
+```
+
+### exit: 1
+
+- - - - - - - - - -
+
+## double-quotes in filter, matching value
+
+### stdout
+```
+value: 'beep "x" boop'
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## double-quotes in filter, non-matching value
+
+### stderr
+```
+the-cmd: Invalid value for option --looks-like-dq-string: beep x boop
+
+the-cmd -- test command
+```
+
+### exit: 1
+
+- - - - - - - - - -
+
+## dollar-substitution-looking thing in filter, matching value
+
+### stdout
+```
+value: 'yes abc'
+```
+
+### exit: 0
+
+- - - - - - - - - -
+
+## dollar-substitution-looking thing in filter, non-matching value
+
+### stderr
+```
+the-cmd: Invalid value for option --looks-like-dollar: no abczz
+
+the-cmd -- test command
+```
+
+### exit: 1

--- a/tests/02-core/02-arg-processor/19-filter-regex/expect.md
+++ b/tests/02-core/02-arg-processor/19-filter-regex/expect.md
@@ -1,26 +1,22 @@
 ## nop filter, empty value
 
-### stderr
+### stdout
 ```
-the-cmd: Invalid value for option --nop: 
-
-the-cmd -- test command
+value: ''
 ```
 
-### exit: 1
+### exit: 0
 
 - - - - - - - - - -
 
 ## nop filter, non-empty value
 
-### stderr
+### stdout
 ```
-the-cmd: Invalid value for option --nop: beep
-
-the-cmd -- test command
+value: beep
 ```
 
-### exit: 1
+### exit: 0
 
 - - - - - - - - - -
 

--- a/tests/02-core/02-arg-processor/19-filter-regex/info.md
+++ b/tests/02-core/02-arg-processor/19-filter-regex/info.md
@@ -1,0 +1,1 @@
+Tests of regex-style `--filter`.

--- a/tests/02-core/02-arg-processor/19-filter-regex/run
+++ b/tests/02-core/02-arg-processor/19-filter-regex/run
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2022-2023 the Bashy-lib Authors (Dan Bornstein et alia).
+# SPDX-License-Identifier: Apache-2.0
+
+[[ "$(readlink -f "$0")" =~ ^(.*/tests/) ]] && . "${BASH_REMATCH[1]}_test-init.sh" || exit 1
+
+cmd="$(this-cmd-dir)/the-cmd"
+
+call-and-log-as-test 'nop filter, empty value' \
+    "${cmd}" --nop=''
+
+call-and-log-as-test 'nop filter, non-empty value' \
+    "${cmd}" --nop=beep
+
+call-and-log-as-test '"non-empty" filter, empty value' \
+    "${cmd}" --non-empty=''
+
+call-and-log-as-test '"non-empty" filter, non-empty value' \
+    "${cmd}" --non-empty=beep
+
+# These test that the regex syntax accepted isn't treated like Bash source, in
+# that quote marks are treated as literals, and `$` always means end-of-input.
+call-and-log-as-test 'single-quotes in filter, matching value' \
+    "${cmd}" --looks-like-sq-string=$'beep \'x\' boop'
+call-and-log-as-test 'single-quotes in filter, non-matching value' \
+    "${cmd}" --looks-like-sq-string=$'beep x boop'
+call-and-log-as-test 'double-quotes in filter, matching value' \
+    "${cmd}" --looks-like-dq-string=$'beep \"x\" boop'
+call-and-log-as-test 'double-quotes in filter, non-matching value' \
+    "${cmd}" --looks-like-dq-string=$'beep x boop'
+call-and-log-as-test 'dollar-substitution-looking thing in filter, matching value' \
+    "${cmd}" --looks-like-dollar=$'yes abc'
+call-and-log-as-test 'dollar-substitution-looking thing in filter, non-matching value' \
+    "${cmd}" --looks-like-dollar=$'no abczz'

--- a/tests/02-core/02-arg-processor/19-filter-regex/the-cmd
+++ b/tests/02-core/02-arg-processor/19-filter-regex/the-cmd
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright 2022-2023 the Bashy-lib Authors (Dan Bornstein et alia).
+# SPDX-License-Identifier: Apache-2.0
+
+[[ "$(readlink -f "$0")" =~ ^(.*/tests/) ]] && . "${BASH_REMATCH[1]}_init.sh" || exit 1
+
+
+#
+# Argument parsing
+#
+
+define-usage $'
+    ${name} -- test command
+
+    This is a test command.
+'
+
+opt-value --var=value --filter='//' nop
+opt-value --var=value --filter='/./' non-empty
+opt-value --var=value --filter=$'/\'x\'/' looks-like-sq-string
+opt-value --var=value --filter='/"x"/' looks-like-dq-string
+
+Z='zzz'
+opt-value --var=value --filter=$'/abc$Z?/' looks-like-dollar
+
+process-args "$@" || exit "$?"
+
+echo "value: $(vals "${value}")"

--- a/tests/02-core/02-arg-processor/19-filter-regex/the-cmd
+++ b/tests/02-core/02-arg-processor/19-filter-regex/the-cmd
@@ -15,7 +15,7 @@ define-usage $'
     This is a test command.
 '
 
-opt-value --var=value --filter='//' nop
+opt-value --var=value --filter='/^/' nop
 opt-value --var=value --filter='/./' non-empty
 opt-value --var=value --filter=$'/\'x\'/' looks-like-sq-string
 opt-value --var=value --filter='/"x"/' looks-like-dq-string

--- a/tests/run-one
+++ b/tests/run-one
@@ -29,9 +29,15 @@ define-usage --with-help $'
     Note that all test directories are expected to be named with a sequential
     numeric prefix followed by a dash.
 
+    --print
+      Print the test run output to stdout, instead of doing a diff with the
+      expected output.
     --update
       Update the expected output to match the actual output.
 '
+
+# Print the test run output?
+opt-toggle --var=doPrint print
 
 # Update the expected output?
 opt-toggle --var=doUpdate update
@@ -204,9 +210,16 @@ testOutput="$("${runScript}")" \
     exit 1
 }
 
+if (( doPrint )); then
+    echo "${testOutput}"
+fi
+
 if (( doUpdate )); then
     echo >"${expectMd}" "${testOutput}" \
     || exit "$?"
+fi
+
+if (( doPrint || doUpdate )); then
     exit
 fi
 


### PR DESCRIPTION
This PR is the follow-on from the previous one. It removes the non-`[]` `--enum` option, and also makes the regex-style filter code get evaluated using the same helper as other filters.