### PR TITLE
Node build stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ versioning principles. Unstable releases do not.
 
 ### [Unreleased]
 
+This is a stable-ish release. No further breaking changes are currently
+contemplated for the 2.* release series.
+
 Breaking changes:
-* None.
+* `bashy-node`: Reworked build options to use the newly-standardized multi-value
+  forms. Only _nominally_ breaking in that use of `bashy-node` at all is
+  pretty minimal.
 
 Other notable changes:
 * `bashy-basics`: New utility functions `env-clean`, `env-minimize`, and

--- a/scripts/lib/bashy-node/node-project/build-main-module
+++ b/scripts/lib/bashy-node/node-project/build-main-module
@@ -28,10 +28,10 @@ define-usage --with-help $'
       files ended up in the built output.
     --modules-dir=<dir>
       Path to a directory containing all module sources to be used.
-    --modules-dirs=<json>
-      JSON array of one or more paths to directories containing module sources.
-      If the same-named module exists in more than one modules directory, the
-      first one listed "wins."
+    --modules-dirs[]=<dir> ...
+      Paths to one or more module source directories, collectively containing
+      all module sources to be used. If there are same-named modules under more
+      than one of the given paths, the first-listed path\'s one "wins."
     --out=<dir>
       Directory where built output goes. Defaults to `out` directly under the
       main product directory.
@@ -46,10 +46,9 @@ define-usage --with-help $'
 # Allow the build to be platform-specific?
 opt-toggle --var=platformSpecific allow-platform-specific-files
 
-# Directory or directories containing all the modules.
-modulesOpt=''
-opt-value --call='{ modulesOpt="--modules-dir=$1" }' --filter='/./' modules-dir
-opt-value --call='{ modulesOpt="--modules-dirs=$1" }' --filter='/^\[.*\]$/' modules-dirs
+# Paths to all module directories.
+opt-value --call='{ modulesDirs=("$1") }' --filter='/./' modules-dir
+opt-multi --var=modulesDirs --filter='/./' modules-dirs
 require-exactly-one-arg-of modules-dir modules-dirs
 
 # Built output directory.
@@ -71,8 +70,9 @@ process-args "$@" || exit "$?"
 # The main actions of this script.
 function build-project {
     local projectName="$1"
-    local modulesOpt="$2"
-    local destDir="$3"
+    local destDir="$2"
+    shift 2
+    local modulesDirs=("$@")
 
     local destLibDir="${destDir}/lib"
     local mainModule="main-${projectName}"
@@ -91,7 +91,9 @@ function build-project {
 
     local deps
     deps="$(
-        lib . find-module-dependencies "${modulesOpt}" "${mainModule}"
+        lib . find-module-dependencies \
+            --modules-dirs[]="$(vals "${modulesDirs[@]}")" \
+            "${mainModule}"
     )" \
     || return "$?"
 
@@ -372,7 +374,7 @@ if [[ ! -d ${outProjectDir} ]]; then
     || exit "$?"
 fi
 
-build-project "${projectName}" "${modulesOpt}" "${outProjectDir}" \
+build-project "${projectName}" "${outProjectDir}" "${modulesDirs[@]}" \
 || exit "$?"
 
 if (( !platformSpecific )); then

--- a/scripts/lib/bashy-node/node-project/build-main-module
+++ b/scripts/lib/bashy-node/node-project/build-main-module
@@ -26,8 +26,7 @@ define-usage --with-help $'
     --allow-platform-specific-files
       If specified, the build does *not* check to see if any platform-specific
       files ended up in the built output.
-    --modules-dir=<dir>
-      Path to a directory containing all module sources to be used.
+    --modules-dirs=<dir>
     --modules-dirs[]=<dir> ...
       Paths to one or more module source directories, collectively containing
       all module sources to be used. If there are same-named modules under more
@@ -47,9 +46,7 @@ define-usage --with-help $'
 opt-toggle --var=platformSpecific allow-platform-specific-files
 
 # Paths to all module directories.
-opt-value --call='{ modulesDirs=("$1") }' --filter='/./' modules-dir
-opt-multi --var=modulesDirs --filter='/./' modules-dirs
-require-exactly-one-arg-of modules-dir modules-dirs
+opt-multi --required --var=modulesDirs --filter='/./' modules-dirs
 
 # Built output directory.
 opt-value --var=outDir out

--- a/scripts/lib/bashy-node/node-project/find-module-dependencies
+++ b/scripts/lib/bashy-node/node-project/find-module-dependencies
@@ -13,9 +13,9 @@
 define-usage --with-help $'
     ${name} [<opt> ...] [--] <module-name>
 
-    Transitively finds all module dependencies from the one given, which must
-    be the name of a module defined under the indicated modules directory.
-    Prints out a JSON object with bindings as follows:
+    Transitively finds all module dependencies from the given <module-name>,
+    which must be the name of a module defined under one of the indicated
+    modules directories. Prints out a JSON object with bindings as follows:
 
     * `main: string` -- The originally requested module.
     * `localDeps: [name, ...]` -- Local module dependencies.
@@ -30,20 +30,15 @@ define-usage --with-help $'
     This tool is opinionated: The modules directories are taken to define
     submodules (in the Node sense) under the top-level name `@this`.
 
-    **Note:** Exactly one of the two `--modules-*` options must be specified.
-
-    --modules-dir=<dir>
-      Path to a directory containing all module sources to be used.
-    --modules-dirs=<json>
-      JSON array of one or more paths to directories containing module sources.
-      If the same-named module exists in more than one modules directory, the
-      first one listed "wins."
+    --modules-dirs=<dir>
+    --modules-dirs[]=<dir> ...
+      Paths to one or more module source directories, collectively containing
+      all module sources to be used. If there are same-named modules under more
+      than one of the given paths, the first-listed path\'s one "wins."
 '
 
-# Directory or directories containing all the modules.
-opt-value --var=modulesDir --filter='/./' modules-dir
-opt-value --var=modulesDirsJson --filter='/^\[.*\]$/' modules-dirs
-require-exactly-one-arg-of modules-dir modules-dirs
+# Paths to all module directories.
+opt-multi --required --var=modulesDirs --filter='/./' modules-dirs
 
 # The module to start at.
 positional-arg --required --var=moduleName module-name
@@ -54,18 +49,6 @@ process-args "$@" || exit "$?"
 #
 # Main script
 #
-
-modulesDirs=()
-if [[ ${modulesDir} != '' ]]; then
-    if [[ ! (-d ${modulesDir} && -r ${modulesDir}) ]]; then
-        error-msg "Not a readable directory: ${modulesDir}"
-        exit 1
-    fi
-    modulesDirs=("${modulesDir}")
-else
-    jset-array --raw modulesDirs "${modulesDirsJson}" \
-    || exit "$?"
-fi
 
 # Collect all of the modules referenced by this package, transitively including
 # all referenced local modules. The result is two lists, one of local modules


### PR DESCRIPTION
This PR gets `bashy-node` to use `opt-multi` instead of the ad-hoc thing it was doing before.